### PR TITLE
Enable data-driven variable names and hence data-driven network structure

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+gRain v1.3.1X (Release date: 2022-XX-XX)
+=======================================
+
+* Enable data-driven variable names and hence data-driven network structure
+
 gRain v1.3.10 (Release date: 2022-05-09)
 =======================================
 

--- a/R/repeat_pattern.R
+++ b/R/repeat_pattern.R
@@ -6,11 +6,14 @@
 #' @param plist A list of conditional probability tables. The variable
 #'     names must have the form \code{name[i]} and the \code{i} will
 #'     be substituted by the values given in \code{instances} below.
+#'     See also the \code{data} argument.
 #' @param instances A vector of distinct integers
 #' @param unlist If \code{FALSE} the result is a list in which each
 #'     element is a copy of \code{plist} in which \code{name[i]} are
 #'     substituted. If \code{TRUE} the result is the result of
 #'     applying \code{unlist()}.
+#' @param data Enable variable names of the form \code{name[data[i]]} - to
+#'     enable data-driven variable names.
 #' 
 #' @author Søren Højsgaard, \email{sorenh@@math.aau.dk}
 #' @seealso \code{\link{grain}}, \code{\link{compileCPT}}
@@ -64,28 +67,40 @@
 #'
 #' if (interactive()) iplot(hmm)
 #' 
+#' ## Data-driven variable names
+#' x0 <- cptable(~x0, values=c(0.5, 0.5), levels=yn)
+#' x <- cptable(~x[i] | x[data[i, "p"]], values=c(0.5, 0.5), levels=yn)
+#' dep <- data.frame(i=c(1, 2, 3, 4, 5, 6, 7, 8),
+#'                   p=c(0, 1, 2, 2, 3, 3, 4, 4))
+#' x <- repeatPattern(list(x), instances=dep$i, data=dep)
+#' tree <- compileCPT(c(list(x0), x))
+#' tree <- grain(tree)
+#' tree 
+#' 
+#' #' if (interactive()) iplot(tree)
+#' 
 #' @export repeatPattern
 #' 
-repeatPattern <- function(plist, instances, unlist=TRUE){
+repeatPattern <- function(plist, instances, unlist=TRUE, data=NULL){
     ans <- vector("list", length(instances))
     for (i in seq_along(instances)){
-        ans[[ i ]] <- .do.one(plist, instances[[ i ]])
+        ans[[ i ]] <- .do.one(plist, instances[[ i ]], data)
     }
     if (unlist)
         ans <- unlist(ans, recursive=FALSE)
     ans
 }
 
-.do.one <- function(plist1, i.val){
+.do.one <- function(plist1, i.val, data=NULL){
     pp <- lapply(plist1, function(xx){
-        ##xx$vpa <- .subst(xx$vpa, i.val)                 ## FIX 14/8/2017
-        attr(xx, "vpa") <- .subst(attr(xx, "vpa"), i.val) ## FIX 14/8/2017
+        ##xx$vpa <- .subst(xx$vpa, i.val)                       ## FIX 14/8/2017
+        attr(xx, "vpa") <- .subst(attr(xx, "vpa"), i.val, data) ## FIX 14/8/2017, 24/7/2022
         xx
     }) 
     pp 
 }
 
-.subst <- function(x, i.val){
+.subst <- function(x, i.val, data=NULL){
     ##vv <- c("xyz[i+1]tyu", "xx[i]")
     ##x <- c("xyz[i+1]tyu", "xx[i]","kkkk")
     ##x <- c("xyztyu", "xx","kkkk")
@@ -95,7 +110,7 @@ repeatPattern <- function(plist, instances, unlist=TRUE){
     if (length(vv)>0){
         idx.vec <- gsub("[^\\[]*\\[([^\\]*)\\].*", "\\1", vv)
         idx.exp <- parse(text=idx.vec)
-        idx.val <- unlist(lapply(idx.exp, eval, list(i=i.val)))
+        idx.val <- unlist(lapply(idx.exp, eval, list(i=i.val, data=data)))
         vv2 <- list()
         for (ii in seq_along(idx.val)){
             vv2[[ii]] <- gsub("\\[([^\\]*)\\]", idx.val[ii], vv[ii])
@@ -105,5 +120,3 @@ repeatPattern <- function(plist, instances, unlist=TRUE){
     }
     x
 }
-
-

--- a/man/repeatPattern.Rd
+++ b/man/repeatPattern.Rd
@@ -4,12 +4,13 @@
 \alias{repeatPattern}
 \title{Create repeated patterns in Bayesian networks}
 \usage{
-repeatPattern(plist, instances, unlist = TRUE)
+repeatPattern(plist, instances, unlist = TRUE, data = NULL)
 }
 \arguments{
 \item{plist}{A list of conditional probability tables. The variable
 names must have the form \code{name[i]} and the \code{i} will
-be substituted by the values given in \code{instances} below.}
+be substituted by the values given in \code{instances} below.
+See also the \code{data} argument.}
 
 \item{instances}{A vector of distinct integers}
 
@@ -17,6 +18,9 @@ be substituted by the values given in \code{instances} below.}
 element is a copy of \code{plist} in which \code{name[i]} are
 substituted. If \code{TRUE} the result is the result of
 applying \code{unlist()}.}
+
+\item{data}{Enable variable names of the form \code{name[data[i]]} -
+to enable data-driven variable names.}
 }
 \description{
 Repeated patterns is a useful model specification
@@ -66,6 +70,18 @@ hmm <- grain(cpt)
 hmm 
 
 if (interactive()) iplot(hmm)
+
+## Data-driven variable names
+x0 <- cptable(~x0, values=c(0.5, 0.5), levels=yn)
+x <- cptable(~x[i] | x[data[i, "p"]], values=c(0.5, 0.5), levels=yn)
+dep <- data.frame(i=c(1, 2, 3, 4, 5, 6, 7, 8),
+                  p=c(0, 1, 2, 2, 3, 3, 4, 4))
+x <- repeatPattern(list(x), instances=dep$i, data=dep)
+tree <- compileCPT(c(list(x0), x))
+tree <- grain(tree)
+tree 
+
+if (interactive()) iplot(tree)
 
 }
 \references{


### PR DESCRIPTION
Hi @hojsgaard!

I tried running an old genetics gRain example and noticed that I can not use data-driven variable name (and network structure) anymore.

I am providing a solution by adding `data` argument to the `repeatPattern()` and its underlying functions.

I added also documentation.

Would this be something you would consider adding to gRain via this Pull Request?

Thanks!
